### PR TITLE
Issue #51: Removed archived items from gift list index

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,11 +3,8 @@ class User < ApplicationRecord
   has_secure_password
 
   has_many :families, :through => :to_pipes, :source => :from, :source_type => 'Family'
+  has_many :family_items, -> { where(archived: false).distinct }, through: :families, source: :items
   has_many :items
 
   validates :name, presence: true
-
-  def family_items
-    families.map(&:items).flatten.uniq
-  end
 end


### PR DESCRIPTION
removes method that showed family items in favour of using rails `through` style with a distinct call and a where statement that only allows any items that are `archived: false`.